### PR TITLE
Add ESPHome lint workflow and LED sync updates

### DIFF
--- a/.github/workflows/esphome-lint.yml
+++ b/.github/workflows/esphome-lint.yml
@@ -1,0 +1,25 @@
+name: ESPHome Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install esphome yamllint
+      - name: Prepare secrets
+        run: cp secrets.yaml.example secrets.yaml
+      - name: Lint YAML
+        run: yamllint switchman_m5_1_gang.yaml switchman_m5_2_gang.yaml
+      - name: Validate configs
+        run: |
+          esphome config switchman_m5_1_gang.yaml
+          esphome config switchman_m5_2_gang.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+secrets.yaml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+extends: default
+rules:
+  document-start: disable
+  line-length:
+    max: 200
+    level: warning

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -1,0 +1,5 @@
+api_key: example_api_key
+wifi_ssid: example_ssid
+wifi_password: example_password
+ota_password: example_password
+ap_password: example_password

--- a/switchman_m5_1_gang.yaml
+++ b/switchman_m5_1_gang.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  device_friendly_name: ""
-  device_name: ""
+  device_friendly_name: "Switchman M5 1G"
+  device_name: "switchman-m5-1g"
   device_ip: ""
   device_make: "Sonoff"
   device_model: "Switchman M5 (1-Gang)"
@@ -157,12 +157,12 @@ captive_portal:
 globals:
   - id: cpu_speed
     type: int
-    restore_value: no
+    restore_value: false
     initial_value: "0"
 
   - id: last_user_toggle_ms
     type: uint32_t
-    restore_value: no
+    restore_value: false
     initial_value: '0'
 
 text_sensor:
@@ -353,6 +353,27 @@ select:
     restore_value: true
     initial_option: ${default_mode_a}
     entity_category: config
+    on_value:
+      then:
+        - if:
+            condition:
+              lambda: 'return id(mode_a).state == std::string("Decoupled");'
+            then:
+              - if:
+                  condition:
+                    switch.is_on: button_a_state
+                  then:
+                    - switch.turn_on: led_indicator
+                  else:
+                    - switch.turn_off: led_indicator
+            else:
+              - if:
+                  condition:
+                    switch.is_on: relay_a
+                  then:
+                    - switch.turn_on: led_indicator
+                  else:
+                    - switch.turn_off: led_indicator
 
   # Exposed selector that defines the enforced relay state when API is connected
   - platform: template

--- a/switchman_m5_2_gang.yaml
+++ b/switchman_m5_2_gang.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  device_friendly_name: ""
-  device_name: ""
+  device_friendly_name: "Switchman M5 2G"
+  device_name: "switchman-m5-2g"
   device_ip: ""
   device_make: "Sonoff"
   device_model: "Switchman M5 (2-Gang)"
@@ -215,17 +215,17 @@ captive_portal:
 globals:
   - id: cpu_speed
     type: int
-    restore_value: no
+    restore_value: false
     initial_value: "0"
 
   # Per-channel quick-tap guards
   - id: last_user_toggle_ms_a
     type: uint32_t
-    restore_value: no
+    restore_value: false
     initial_value: '0'
   - id: last_user_toggle_ms_b
     type: uint32_t
-    restore_value: no
+    restore_value: false
     initial_value: '0'
 
 text_sensor:
@@ -493,6 +493,27 @@ select:
     restore_value: true
     initial_option: ${default_mode_b}
     entity_category: config
+    on_value:
+      then:
+        - if:
+            condition:
+              lambda: 'return id(mode_b).state == std::string("Decoupled");'
+            then:
+              - if:
+                  condition:
+                    switch.is_on: button_b_state
+                  then:
+                    - switch.turn_on: led_indicator
+                  else:
+                    - switch.turn_off: led_indicator
+            else:
+              - if:
+                  condition:
+                    switch.is_on: relay_b
+                  then:
+                    - switch.turn_on: led_indicator
+                  else:
+                    - switch.turn_off: led_indicator
 
   # Connected target modes
   - platform: template


### PR DESCRIPTION
## Summary
- add CI workflow to lint and validate ESPHome configs
- track secrets locally and provide lint defaults
- sync LED indicator with mode changes for both 1-gang and 2-gang templates

## Testing
- `yamllint switchman_m5_1_gang.yaml switchman_m5_2_gang.yaml`
- `esphome config switchman_m5_1_gang.yaml`
- `esphome config switchman_m5_2_gang.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a7d96477848324a5f7a3ec5094e88e