### PR TITLE
Add ESPHome lint workflow, LED sync updates, and project README

### DIFF
--- a/.github/workflows/esphome-lint.yml
+++ b/.github/workflows/esphome-lint.yml
@@ -1,0 +1,25 @@
+name: ESPHome Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install esphome yamllint
+      - name: Prepare secrets
+        run: cp secrets.yaml.example secrets.yaml
+      - name: Lint YAML
+        run: yamllint switchman_m5_1_gang.yaml switchman_m5_2_gang.yaml
+      - name: Validate configs
+        run: |
+          esphome config switchman_m5_1_gang.yaml
+          esphome config switchman_m5_2_gang.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+secrets.yaml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+extends: default
+rules:
+  document-start: disable
+  line-length:
+    max: 200
+    level: warning

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# ESPHome Sonoff SwitchMan M5 Templates
+
+This repository contains reusable ESPHome packages for Sonoff's SwitchMan M5 wall switches.
+It provides separate templates for the **1‑gang** and **2‑gang** models that expose common
+substitutions so each device can be configured with a small "mini" file.
+
+## Features
+- Coupled/decoupled modes with automatic LED indicator synchronisation
+- Fallback to coupled mode when Wi‑Fi or API is unavailable
+- Placeholder secrets and linting defaults for safer configuration management
+- GitHub Actions workflow to lint and validate the YAML templates on push
+
+## Usage
+Create a per-device YAML that defines the required substitutions and pulls in the
+appropriate template via `packages`. Example for the 1‑gang version:
+
+```yaml
+substitutions:
+  device_friendly_name: "Entrance light switch 1"
+  device_name: "entrance-light-switch-1"
+  api_key: !secret api_key
+  wifi_ssid: !secret wifi_ssid
+  wifi_password: !secret wifi_password
+  ota_password: !secret ota_password
+  ap_password: !secret ap_password
+
+packages:
+  remote_package:
+    url: https://github.com/bitosome/esphome-sonoff
+    ref: main
+    files: [switchman_m5_1_gang.yaml]
+    refresh: 0s
+```
+
+Before building locally, copy `secrets.yaml.example` to `secrets.yaml` and adjust the values.
+
+## Development
+Run lint and compile checks before committing:
+
+```bash
+yamllint switchman_m5_1_gang.yaml switchman_m5_2_gang.yaml
+esphome config switchman_m5_1_gang.yaml
+esphome config switchman_m5_2_gang.yaml
+```
+

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -1,0 +1,5 @@
+api_key: example_api_key
+wifi_ssid: example_ssid
+wifi_password: example_password
+ota_password: example_password
+ap_password: example_password

--- a/switchman_m5_1_gang.yaml
+++ b/switchman_m5_1_gang.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  device_friendly_name: ""
-  device_name: ""
+  device_friendly_name: "Switchman M5 1G"
+  device_name: "switchman-m5-1g"
   device_ip: ""
   device_make: "Sonoff"
   device_model: "Switchman M5 (1-Gang)"
@@ -157,12 +157,12 @@ captive_portal:
 globals:
   - id: cpu_speed
     type: int
-    restore_value: no
+    restore_value: false
     initial_value: "0"
 
   - id: last_user_toggle_ms
     type: uint32_t
-    restore_value: no
+    restore_value: false
     initial_value: '0'
 
 text_sensor:
@@ -353,6 +353,27 @@ select:
     restore_value: true
     initial_option: ${default_mode_a}
     entity_category: config
+    on_value:
+      then:
+        - if:
+            condition:
+              lambda: 'return id(mode_a).state == std::string("Decoupled");'
+            then:
+              - if:
+                  condition:
+                    switch.is_on: button_a_state
+                  then:
+                    - switch.turn_on: led_indicator
+                  else:
+                    - switch.turn_off: led_indicator
+            else:
+              - if:
+                  condition:
+                    switch.is_on: relay_a
+                  then:
+                    - switch.turn_on: led_indicator
+                  else:
+                    - switch.turn_off: led_indicator
 
   # Exposed selector that defines the enforced relay state when API is connected
   - platform: template

--- a/switchman_m5_2_gang.yaml
+++ b/switchman_m5_2_gang.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  device_friendly_name: ""
-  device_name: ""
+  device_friendly_name: "Switchman M5 2G"
+  device_name: "switchman-m5-2g"
   device_ip: ""
   device_make: "Sonoff"
   device_model: "Switchman M5 (2-Gang)"
@@ -215,17 +215,17 @@ captive_portal:
 globals:
   - id: cpu_speed
     type: int
-    restore_value: no
+    restore_value: false
     initial_value: "0"
 
   # Per-channel quick-tap guards
   - id: last_user_toggle_ms_a
     type: uint32_t
-    restore_value: no
+    restore_value: false
     initial_value: '0'
   - id: last_user_toggle_ms_b
     type: uint32_t
-    restore_value: no
+    restore_value: false
     initial_value: '0'
 
 text_sensor:
@@ -493,6 +493,27 @@ select:
     restore_value: true
     initial_option: ${default_mode_b}
     entity_category: config
+    on_value:
+      then:
+        - if:
+            condition:
+              lambda: 'return id(mode_b).state == std::string("Decoupled");'
+            then:
+              - if:
+                  condition:
+                    switch.is_on: button_b_state
+                  then:
+                    - switch.turn_on: led_indicator
+                  else:
+                    - switch.turn_off: led_indicator
+            else:
+              - if:
+                  condition:
+                    switch.is_on: relay_b
+                  then:
+                    - switch.turn_on: led_indicator
+                  else:
+                    - switch.turn_off: led_indicator
 
   # Connected target modes
   - platform: template


### PR DESCRIPTION
## Summary
- add CI workflow to lint and validate ESPHome configs
- track secrets locally and provide lint defaults
- sync LED indicator with mode changes for both 1-gang and 2-gang templates
- document project overview and usage in README

## Testing
- `yamllint switchman_m5_1_gang.yaml switchman_m5_2_gang.yaml`
- `esphome config switchman_m5_1_gang.yaml`
- `esphome config switchman_m5_2_gang.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a7d96477848324a5f7a3ec5094e88e