### PR TITLE
refactor: remove connectivity fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,23 @@ substitutions so each device can be configured with a small "mini" file.
 
 ## Features
 - Coupled/decoupled modes with automatic LED indicator synchronisation
-- Fallback to coupled mode when Wi‑Fi or API is unavailable
 - Placeholder secrets and linting defaults for safer configuration management
 - GitHub Actions workflow to lint and validate the YAML templates on push
+
+## Behaviour
+
+### Button and relay interaction
+
+- Each channel exposes a virtual button state (`button_a_state` / `button_b_state`) that can be decoupled from its physical relay.
+- In **Coupled** mode a button press toggles the relay and keeps the virtual state in sync.
+- In **Decoupled** mode a button press only flips the virtual state and fires the Home‑Assistant actions while the relay remains unchanged.
+
+### Blue status LED
+
+- The blue LED is dedicated to **Button A**. It lights whenever `button_a_state` is on or Relay A energises.
+- In Coupled mode Relay A updates `button_a_state`, keeping the LED aligned with the relay.
+- In Decoupled mode the LED follows `button_a_state` only, allowing the relay to stay on while the LED is off (or vice versa).
+- Button B currently has no blue LED indicator.
 
 ## Usage
 Create a per-device YAML that defines the required substitutions and pulls in the

--- a/switchman_m5_1_gang.yaml
+++ b/switchman_m5_1_gang.yaml
@@ -34,7 +34,7 @@ substitutions:
   timing_hold_repeat: 500ms
 
   default_mode_a: "Coupled"               # Coupled | Decoupled
-  default_relay_a_target_mode: "Off"      # "On" or "Off" when HA/API is available
+  default_relay_a_target_mode: "Off"      # "On" or "Off"
   min_toggle_interval_ms: "250"           # ignore extra presses faster than this
 
   # HA service wiring (leave empty to do nothing)
@@ -94,55 +94,12 @@ wifi:
   ap:
     ssid: ${device_name}
     password: ${ap_password}
-  on_disconnect:
-    then:
-      - if:
-          condition:
-            lambda: 'return id(mode_a).state != std::string("Coupled");'
-          then:
-            - logger.log: "Wi-Fi lost -> preemptively entering fallback (Coupled)"
-            - select.set:
-                id: mode_a
-                option: "Coupled"
 
 ota:
   - platform: esphome
     password: ${ota_password}
 
 api:
-  on_client_connected:
-    then:
-      - logger.log: "API connected -> leaving fallback and restoring defaults"
-      - light.turn_off: led_status
-      - select.set:
-          id: mode_a
-          option: "${default_mode_a}"
-      - if:
-          condition:
-            lambda: 'return id(relay_a_target_mode).state == std::string("On");'
-          then:
-            - switch.turn_on: relay_a
-          else:
-            - switch.turn_off: relay_a
-
-  on_client_disconnected:
-    then:
-      - logger.log: "API disconnected -> entering fallback (Coupled) and resyncing with button"
-      - light.turn_on: led_status
-      - select.set:
-          id: mode_a
-          option: "Coupled"
-      - if:
-          condition:
-            lambda: 'return id(button_a_state).state != id(relay_a).state;'
-          then:
-            - if:
-                condition:
-                  lambda: 'return id(button_a_state).state;'
-                then:
-                  - switch.turn_on: relay_a
-                else:
-                  - switch.turn_off: relay_a
 
 web_server:
   port: 80
@@ -375,7 +332,7 @@ select:
                   else:
                     - switch.turn_off: led_indicator
 
-  # Exposed selector that defines the enforced relay state when API is connected
+  # Exposed selector that defines the relay state target
   - platform: template
     id: relay_a_target_mode
     name: "Relay A target mode"
@@ -390,15 +347,11 @@ select:
       then:
         - if:
             condition:
-              lambda: 'return global_api_server->is_connected();'
+              lambda: 'return id(relay_a_target_mode).state == std::string("On");'
             then:
-              - if:
-                  condition:
-                    lambda: 'return id(relay_a_target_mode).state == std::string("On");'
-                  then:
-                    - switch.turn_on: relay_a
-                  else:
-                    - switch.turn_off: relay_a
+              - switch.turn_on: relay_a
+            else:
+              - switch.turn_off: relay_a
 
 number: []
 
@@ -423,13 +376,9 @@ binary_sensor:
             - lambda: 'id(last_user_toggle_ms) = millis();'
             - if:
                 condition:
-                  lambda: |-
-                    const bool connected = global_api_server->is_connected();
-                    const bool coupled = (id(mode_a).state == std::string("Coupled"));
-                    const bool decoupled_failover = !connected && (id(mode_a).state == std::string("Decoupled"));
-                    return coupled || decoupled_failover;
+                  lambda: 'return id(mode_a).state == std::string("Coupled");'
                 then:
-                  # In Coupled (or failover), toggle relay and fire on/off action based on resulting state
+                  # In Coupled mode, toggle relay and fire on/off action based on resulting state
                   - if:
                       condition:
                         lambda: 'return id(relay_a).state == false;'
@@ -439,7 +388,7 @@ binary_sensor:
                         - script.execute: a_off_action
                   - switch.toggle: relay_a
                 else:
-                  # In Decoupled with API, toggle button state (triggers a_*_action)
+                  # In Decoupled mode, toggle button state (triggers a_*_action)
                   - switch.toggle: button_a_state
     on_multi_click:
       # Double click

--- a/switchman_m5_2_gang.yaml
+++ b/switchman_m5_2_gang.yaml
@@ -37,8 +37,8 @@ substitutions:
 
   default_mode_a: "Coupled"              # "Coupled" | "Decoupled"
   default_mode_b: "Coupled"              # "Coupled" | "Decoupled"
-  default_relay_a_target_mode: "Off"     # "On" | "Off" when HA/API is available
-  default_relay_b_target_mode: "Off"     # "On" | "Off" when HA/API is available
+  default_relay_a_target_mode: "Off"     # "On" | "Off"
+  default_relay_b_target_mode: "Off"     # "On" | "Off"
   min_toggle_interval_ms: "250"          # ignore extra presses faster than this
 
   # HA actions — A
@@ -123,84 +123,12 @@ wifi:
   ap:
     ssid: ${device_name}
     password: ${ap_password}
-  on_disconnect:
-    then:
-      - if:
-          condition:
-            lambda: 'return id(mode_a).state != std::string("Coupled") || id(mode_b).state != std::string("Coupled");'
-          then:
-            - logger.log: "Wi-Fi lost -> preemptively entering fallback (Coupled) for A & B"
-            - select.set:
-                id: mode_a
-                option: "Coupled"
-            - select.set:
-                id: mode_b
-                option: "Coupled"
 
 ota:
   - platform: esphome
     password: ${ota_password}
 
 api:
-  on_client_connected:
-    then:
-      - logger.log: "API connected -> leaving fallback and restoring defaults"
-      - light.turn_off: led_status
-      - select.set:
-          id: mode_a
-          option: "${default_mode_a}"
-      - select.set:
-          id: mode_b
-          option: "${default_mode_b}"
-      # Enforce relay targets when API is up
-      - if:
-          condition:
-            lambda: 'return id(relay_a_target_mode).state == std::string("On");'
-          then:
-            - switch.turn_on: relay_a
-          else:
-            - switch.turn_off: relay_a
-      - if:
-          condition:
-            lambda: 'return id(relay_b_target_mode).state == std::string("On");'
-          then:
-            - switch.turn_on: relay_b
-          else:
-            - switch.turn_off: relay_b
-
-  on_client_disconnected:
-    then:
-      - logger.log: "API disconnected -> entering fallback (Coupled) and resyncing with buttons"
-      - light.turn_on: led_status
-      - select.set:
-          id: mode_a
-          option: "Coupled"
-      - select.set:
-          id: mode_b
-          option: "Coupled"
-      # Resync relays with button states
-      - if:
-          condition:
-            lambda: 'return id(button_a_state).state != id(relay_a).state;'
-          then:
-            - if:
-                condition:
-                  lambda: 'return id(button_a_state).state;'
-                then:
-                  - switch.turn_on: relay_a
-                else:
-                  - switch.turn_off: relay_a
-      - if:
-          condition:
-            lambda: 'return id(button_b_state).state != id(relay_b).state;'
-          then:
-            - if:
-                condition:
-                  lambda: 'return id(button_b_state).state;'
-                then:
-                  - switch.turn_on: relay_b
-                else:
-                  - switch.turn_off: relay_b
 
 web_server:
   port: 80
@@ -374,12 +302,14 @@ switch:
     pin: ${relay_a_gpio}
     restore_mode: RESTORE_DEFAULT_OFF
     on_turn_on:
+      - light.turn_on: led_status
       - if:
           condition:
             lambda: 'return id(mode_a).state == std::string("Coupled") && id(button_a_state).state == false;'
           then:
             - switch.turn_on: button_a_state
     on_turn_off:
+      - light.turn_off: led_status
       - if:
           condition:
             lambda: 'return id(mode_a).state == std::string("Coupled") && id(button_a_state).state == true;'
@@ -414,6 +344,7 @@ switch:
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
     on_turn_on:
+      - light.turn_on: led_status
       # Only call HA action when DECOUPLED
       - if:
           condition:
@@ -427,6 +358,7 @@ switch:
           then:
             - switch.turn_on: relay_a
     on_turn_off:
+      - light.turn_off: led_status
       # Only call HA action when DECOUPLED
       - if:
           condition:
@@ -515,7 +447,7 @@ select:
                   else:
                     - switch.turn_off: led_indicator
 
-  # Connected target modes
+  # Relay target modes
   - platform: template
     id: relay_a_target_mode
     name: "Relay A target mode"
@@ -530,15 +462,11 @@ select:
       then:
         - if:
             condition:
-              lambda: 'return global_api_server->is_connected();'
+              lambda: 'return id(relay_a_target_mode).state == std::string("On");'
             then:
-              - if:
-                  condition:
-                    lambda: 'return id(relay_a_target_mode).state == std::string("On");'
-                  then:
-                    - switch.turn_on: relay_a
-                  else:
-                    - switch.turn_off: relay_a
+              - switch.turn_on: relay_a
+            else:
+              - switch.turn_off: relay_a
 
   - platform: template
     id: relay_b_target_mode
@@ -554,15 +482,11 @@ select:
       then:
         - if:
             condition:
-              lambda: 'return global_api_server->is_connected();'
+              lambda: 'return id(relay_b_target_mode).state == std::string("On");'
             then:
-              - if:
-                  condition:
-                    lambda: 'return id(relay_b_target_mode).state == std::string("On");'
-                  then:
-                    - switch.turn_on: relay_b
-                  else:
-                    - switch.turn_off: relay_b
+              - switch.turn_on: relay_b
+            else:
+              - switch.turn_off: relay_b
 
 number: []
 
@@ -587,13 +511,9 @@ binary_sensor:
             - lambda: 'id(last_user_toggle_ms_a) = millis();'
             - if:
                 condition:
-                  lambda: |-
-                    const bool connected = global_api_server->is_connected();
-                    const bool coupled = (id(mode_a).state == std::string("Coupled"));
-                    const bool decoupled_failover = !connected && (id(mode_a).state == std::string("Decoupled"));
-                    return coupled || decoupled_failover;
+                  lambda: 'return id(mode_a).state == std::string("Coupled");'
                 then:
-                  # In Coupled (or failover), toggle relay and fire HA action based on resulting state
+                  # In Coupled mode, toggle relay and fire HA action based on resulting state
                   - if:
                       condition:
                         lambda: 'return id(relay_a).state == false;'
@@ -603,7 +523,7 @@ binary_sensor:
                         - script.execute: a_off_action
                   - switch.toggle: relay_a
                 else:
-                  # In Decoupled with API, toggle virtual state (triggers a_*_action)
+                  # In Decoupled mode, toggle virtual state (triggers a_*_action)
                   - switch.toggle: button_a_state
     on_multi_click:
       - timing:
@@ -647,13 +567,9 @@ binary_sensor:
             - lambda: 'id(last_user_toggle_ms_b) = millis();'
             - if:
                 condition:
-                  lambda: |-
-                    const bool connected = global_api_server->is_connected();
-                    const bool coupled = (id(mode_b).state == std::string("Coupled"));
-                    const bool decoupled_failover = !connected && (id(mode_b).state == std::string("Decoupled"));
-                    return coupled || decoupled_failover;
+                  lambda: 'return id(mode_b).state == std::string("Coupled");'
                 then:
-                  # In Coupled (or failover), toggle relay and fire HA action based on resulting state
+                  # In Coupled mode, toggle relay and fire HA action based on resulting state
                   - if:
                       condition:
                         lambda: 'return id(relay_b).state == false;'
@@ -663,7 +579,7 @@ binary_sensor:
                         - script.execute: b_off_action
                   - switch.toggle: relay_b
                 else:
-                  # In Decoupled with API, toggle virtual state (triggers b_*_action)
+                  # In Decoupled mode, toggle virtual state (triggers b_*_action)
                   - switch.toggle: button_b_state
     on_multi_click:
       - timing:


### PR DESCRIPTION
## Summary
- remove Wi-Fi/API fallback handling from templates and docs
- simplify button logic to depend solely on Coupled/Decoupled mode

## Testing
- `yamllint switchman_m5_1_gang.yaml switchman_m5_2_gang.yaml`
- `esphome config switchman_m5_1_gang.yaml`
- `esphome config switchman_m5_2_gang.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a81f49701883249720e21ff0681374