### PR TITLE
Remove fallback logic and rely on constant connectivity

### DIFF
--- a/switchman_m5_1_gang.yaml
+++ b/switchman_m5_1_gang.yaml
@@ -10,7 +10,6 @@ substitutions:
   wifi_ssid: !secret wifi_ssid
   wifi_password: !secret wifi_password
   ota_password: !secret ota_password
-  ap_password: !secret ap_password
 
   button_a_gpio: GPIO00
   relay_a_gpio: GPIO23
@@ -91,58 +90,12 @@ wifi:
   power_save_mode: none
   ssid: ${wifi_ssid}
   password: ${wifi_password}
-  ap:
-    ssid: ${device_name}
-    password: ${ap_password}
-  on_disconnect:
-    then:
-      - if:
-          condition:
-            lambda: 'return id(mode_a).state != std::string("Coupled");'
-          then:
-            - logger.log: "Wi-Fi lost -> preemptively entering fallback (Coupled)"
-            - select.set:
-                id: mode_a
-                option: "Coupled"
 
 ota:
   - platform: esphome
     password: ${ota_password}
 
 api:
-  on_client_connected:
-    then:
-      - logger.log: "API connected -> leaving fallback and restoring defaults"
-      - light.turn_off: led_status
-      - select.set:
-          id: mode_a
-          option: "${default_mode_a}"
-      - if:
-          condition:
-            lambda: 'return id(relay_a_target_mode).state == std::string("On");'
-          then:
-            - switch.turn_on: relay_a
-          else:
-            - switch.turn_off: relay_a
-
-  on_client_disconnected:
-    then:
-      - logger.log: "API disconnected -> entering fallback (Coupled) and resyncing with button"
-      - light.turn_on: led_status
-      - select.set:
-          id: mode_a
-          option: "Coupled"
-      - if:
-          condition:
-            lambda: 'return id(button_a_state).state != id(relay_a).state;'
-          then:
-            - if:
-                condition:
-                  lambda: 'return id(button_a_state).state;'
-                then:
-                  - switch.turn_on: relay_a
-                else:
-                  - switch.turn_off: relay_a
 
 web_server:
   port: 80
@@ -151,8 +104,6 @@ time:
   - platform: sntp
     id: time_service
     timezone: ${timezone}
-
-captive_portal:
 
 globals:
   - id: cpu_speed
@@ -281,7 +232,7 @@ light:
       number: ${led_status_gpio}
       inverted: true
       ignore_strapping_warning: true
-    restore_mode: RESTORE_DEFAULT_ON
+    restore_mode: RESTORE_DEFAULT_OFF
 
 switch:
   - platform: gpio
@@ -390,15 +341,11 @@ select:
       then:
         - if:
             condition:
-              lambda: 'return global_api_server->is_connected();'
+              lambda: 'return id(relay_a_target_mode).state == std::string("On");'
             then:
-              - if:
-                  condition:
-                    lambda: 'return id(relay_a_target_mode).state == std::string("On");'
-                  then:
-                    - switch.turn_on: relay_a
-                  else:
-                    - switch.turn_off: relay_a
+              - switch.turn_on: relay_a
+            else:
+              - switch.turn_off: relay_a
 
 number: []
 
@@ -423,13 +370,9 @@ binary_sensor:
             - lambda: 'id(last_user_toggle_ms) = millis();'
             - if:
                 condition:
-                  lambda: |-
-                    const bool connected = global_api_server->is_connected();
-                    const bool coupled = (id(mode_a).state == std::string("Coupled"));
-                    const bool decoupled_failover = !connected && (id(mode_a).state == std::string("Decoupled"));
-                    return coupled || decoupled_failover;
+                  lambda: 'return id(mode_a).state == std::string("Coupled");'
                 then:
-                  # In Coupled (or failover), toggle relay and fire on/off action based on resulting state
+                  # In Coupled, toggle relay and fire on/off action based on resulting state
                   - if:
                       condition:
                         lambda: 'return id(relay_a).state == false;'
@@ -439,7 +382,7 @@ binary_sensor:
                         - script.execute: a_off_action
                   - switch.toggle: relay_a
                 else:
-                  # In Decoupled with API, toggle button state (triggers a_*_action)
+                  # In Decoupled, toggle button state (triggers a_*_action)
                   - switch.toggle: button_a_state
     on_multi_click:
       # Double click

--- a/switchman_m5_2_gang.yaml
+++ b/switchman_m5_2_gang.yaml
@@ -10,7 +10,6 @@ substitutions:
   wifi_ssid: !secret wifi_ssid
   wifi_password: !secret wifi_password
   ota_password: !secret ota_password
-  ap_password: !secret ap_password
 
   button_a_gpio: GPIO04
   button_b_gpio: GPIO15
@@ -120,87 +119,12 @@ wifi:
   power_save_mode: none
   ssid: ${wifi_ssid}
   password: ${wifi_password}
-  ap:
-    ssid: ${device_name}
-    password: ${ap_password}
-  on_disconnect:
-    then:
-      - if:
-          condition:
-            lambda: 'return id(mode_a).state != std::string("Coupled") || id(mode_b).state != std::string("Coupled");'
-          then:
-            - logger.log: "Wi-Fi lost -> preemptively entering fallback (Coupled) for A & B"
-            - select.set:
-                id: mode_a
-                option: "Coupled"
-            - select.set:
-                id: mode_b
-                option: "Coupled"
 
 ota:
   - platform: esphome
     password: ${ota_password}
 
 api:
-  on_client_connected:
-    then:
-      - logger.log: "API connected -> leaving fallback and restoring defaults"
-      - light.turn_off: led_status
-      - select.set:
-          id: mode_a
-          option: "${default_mode_a}"
-      - select.set:
-          id: mode_b
-          option: "${default_mode_b}"
-      # Enforce relay targets when API is up
-      - if:
-          condition:
-            lambda: 'return id(relay_a_target_mode).state == std::string("On");'
-          then:
-            - switch.turn_on: relay_a
-          else:
-            - switch.turn_off: relay_a
-      - if:
-          condition:
-            lambda: 'return id(relay_b_target_mode).state == std::string("On");'
-          then:
-            - switch.turn_on: relay_b
-          else:
-            - switch.turn_off: relay_b
-
-  on_client_disconnected:
-    then:
-      - logger.log: "API disconnected -> entering fallback (Coupled) and resyncing with buttons"
-      - light.turn_on: led_status
-      - select.set:
-          id: mode_a
-          option: "Coupled"
-      - select.set:
-          id: mode_b
-          option: "Coupled"
-      # Resync relays with button states
-      - if:
-          condition:
-            lambda: 'return id(button_a_state).state != id(relay_a).state;'
-          then:
-            - if:
-                condition:
-                  lambda: 'return id(button_a_state).state;'
-                then:
-                  - switch.turn_on: relay_a
-                else:
-                  - switch.turn_off: relay_a
-      - if:
-          condition:
-            lambda: 'return id(button_b_state).state != id(relay_b).state;'
-          then:
-            - if:
-                condition:
-                  lambda: 'return id(button_b_state).state;'
-                then:
-                  - switch.turn_on: relay_b
-                else:
-                  - switch.turn_off: relay_b
 
 web_server:
   port: 80
@@ -209,8 +133,6 @@ time:
   - platform: sntp
     id: time_service
     timezone: ${timezone}
-
-captive_portal:
 
 globals:
   - id: cpu_speed
@@ -357,7 +279,7 @@ light:
       number: ${led_status_gpio}
       inverted: true
       ignore_strapping_warning: true
-    restore_mode: RESTORE_DEFAULT_ON
+    restore_mode: RESTORE_DEFAULT_OFF
 
 switch:
   # Red indicator (mirrors channel B), hidden
@@ -534,15 +456,11 @@ select:
       then:
         - if:
             condition:
-              lambda: 'return global_api_server->is_connected();'
+              lambda: 'return id(relay_a_target_mode).state == std::string("On");'
             then:
-              - if:
-                  condition:
-                    lambda: 'return id(relay_a_target_mode).state == std::string("On");'
-                  then:
-                    - switch.turn_on: relay_a
-                  else:
-                    - switch.turn_off: relay_a
+              - switch.turn_on: relay_a
+            else:
+              - switch.turn_off: relay_a
 
   - platform: template
     id: relay_b_target_mode
@@ -558,15 +476,11 @@ select:
       then:
         - if:
             condition:
-              lambda: 'return global_api_server->is_connected();'
+              lambda: 'return id(relay_b_target_mode).state == std::string("On");'
             then:
-              - if:
-                  condition:
-                    lambda: 'return id(relay_b_target_mode).state == std::string("On");'
-                  then:
-                    - switch.turn_on: relay_b
-                  else:
-                    - switch.turn_off: relay_b
+              - switch.turn_on: relay_b
+            else:
+              - switch.turn_off: relay_b
 
 number: []
 
@@ -591,13 +505,9 @@ binary_sensor:
             - lambda: 'id(last_user_toggle_ms_a) = millis();'
             - if:
                 condition:
-                  lambda: |-
-                    const bool connected = global_api_server->is_connected();
-                    const bool coupled = (id(mode_a).state == std::string("Coupled"));
-                    const bool decoupled_failover = !connected && (id(mode_a).state == std::string("Decoupled"));
-                    return coupled || decoupled_failover;
+                  lambda: 'return id(mode_a).state == std::string("Coupled");'
                 then:
-                  # In Coupled (or failover), toggle relay and fire HA action based on resulting state
+                  # In Coupled, toggle relay and fire HA action based on resulting state
                   - if:
                       condition:
                         lambda: 'return id(relay_a).state == false;'
@@ -607,7 +517,7 @@ binary_sensor:
                         - script.execute: a_off_action
                   - switch.toggle: relay_a
                 else:
-                  # In Decoupled with API, toggle virtual state (triggers a_*_action)
+                  # In Decoupled, toggle virtual state (triggers a_*_action)
                   - switch.toggle: button_a_state
     on_multi_click:
       - timing:
@@ -651,13 +561,9 @@ binary_sensor:
             - lambda: 'id(last_user_toggle_ms_b) = millis();'
             - if:
                 condition:
-                  lambda: |-
-                    const bool connected = global_api_server->is_connected();
-                    const bool coupled = (id(mode_b).state == std::string("Coupled"));
-                    const bool decoupled_failover = !connected && (id(mode_b).state == std::string("Decoupled"));
-                    return coupled || decoupled_failover;
+                  lambda: 'return id(mode_b).state == std::string("Coupled");'
                 then:
-                  # In Coupled (or failover), toggle relay and fire HA action based on resulting state
+                  # In Coupled, toggle relay and fire HA action based on resulting state
                   - if:
                       condition:
                         lambda: 'return id(relay_b).state == false;'
@@ -667,7 +573,7 @@ binary_sensor:
                         - script.execute: b_off_action
                   - switch.toggle: relay_b
                 else:
-                  # In Decoupled with API, toggle virtual state (triggers b_*_action)
+                  # In Decoupled, toggle virtual state (triggers b_*_action)
                   - switch.toggle: button_b_state
     on_multi_click:
       - timing:


### PR DESCRIPTION
## Summary
- drop Wi-Fi/AP fallback handling and assume Home Assistant is always reachable
- default LED state to connected behavior and simplify button press logic

## Testing
- `yamllint switchman_m5_1_gang.yaml switchman_m5_2_gang.yaml`
- `esphome config switchman_m5_1_gang.yaml` *(fails: Error reading file secrets.yaml)*
- `esphome config switchman_m5_2_gang.yaml` *(fails: Error reading file secrets.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68abe864ab988324857a4be8907aff2b