### PR TITLE
Avoid single-click triggers during double clicks

### DIFF
--- a/switchman_m5_1_gang.yaml
+++ b/switchman_m5_1_gang.yaml
@@ -23,7 +23,9 @@ substitutions:
   filter_delay_on: 50ms
   filter_delay_off: 50ms
 
-  # Double & hold timings (single is instant via on_press)
+  # Click timings
+  timing_single_click_1: ON for at most 300ms
+  timing_single_click_2: OFF for at least 250ms
   timing_double_click_1: ON for at most 300ms
   timing_double_click_2: OFF for at most 200ms
   timing_double_click_3: ON for at most 300ms
@@ -111,6 +113,13 @@ globals:
     restore_value: false
     initial_value: "0"
 
+  # Group quick-tap guard
+  - id: last_group_toggle_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  # Per-channel quick-tap guard
   - id: last_user_toggle_ms
     type: uint32_t
     restore_value: false
@@ -350,7 +359,7 @@ select:
 number: []
 
 binary_sensor:
-  # Physical A — INSTANT single via on_press (with quick-tap guard)
+  # Physical A — single/double/hold handling with quick-tap guard
   - platform: gpio
     id: button_a
     internal: true
@@ -362,28 +371,6 @@ binary_sensor:
     filters:
       - delayed_on: ${filter_delay_on}
       - delayed_off: ${filter_delay_off}
-    on_press:
-      - if:
-          condition:
-            lambda: 'return (millis() - id(last_user_toggle_ms)) >= (uint32_t) ${min_toggle_interval_ms};'
-          then:
-            - lambda: 'id(last_user_toggle_ms) = millis();'
-            - if:
-                condition:
-                  lambda: 'return id(mode_a).state == std::string("Coupled");'
-                then:
-                  # In Coupled, toggle relay and fire on/off action based on resulting state
-                  - if:
-                      condition:
-                        lambda: 'return id(relay_a).state == false;'
-                      then:
-                        - script.execute: a_on_action
-                      else:
-                        - script.execute: a_off_action
-                  - switch.toggle: relay_a
-                else:
-                  # In Decoupled, toggle button state (triggers a_*_action)
-                  - switch.toggle: button_a_state
     on_multi_click:
       # Double click
       - timing:
@@ -407,6 +394,38 @@ binary_sensor:
                 - script.execute: a_hold_action
                 - delay: ${timing_hold_repeat}
           - light.turn_off: led_status
+      # Single click
+      - timing:
+          - ${timing_single_click_1}
+          - ${timing_single_click_2}
+        then:
+          - if:
+              condition:
+                lambda: 'return (millis() - id(last_group_toggle_ms)) >= (uint32_t) ${min_toggle_interval_ms};'
+              then:
+                - if:
+                    condition:
+                      lambda: 'return (millis() - id(last_user_toggle_ms)) >= (uint32_t) ${min_toggle_interval_ms};'
+                    then:
+                      - lambda: |-
+                          id(last_user_toggle_ms) = millis();
+                          id(last_group_toggle_ms) = id(last_user_toggle_ms);
+                      - if:
+                          condition:
+                            lambda: 'return id(mode_a).state == std::string("Coupled");'
+                          then:
+                            # In Coupled, toggle relay and fire on/off action based on resulting state
+                            - if:
+                                condition:
+                                  lambda: 'return id(relay_a).state == false;'
+                                then:
+                                  - script.execute: a_on_action
+                                else:
+                                  - script.execute: a_off_action
+                            - switch.toggle: relay_a
+                          else:
+                            # In Decoupled, toggle button state (triggers a_*_action)
+                            - switch.toggle: button_a_state
 
 script:
   - id: a_on_action

--- a/switchman_m5_2_gang.yaml
+++ b/switchman_m5_2_gang.yaml
@@ -25,7 +25,9 @@ substitutions:
   filter_delay_on: 50ms
   filter_delay_off: 50ms
 
-  # Double & hold timings (single is instant via on_press)
+  # Click timings
+  timing_single_click_1: ON for at most 300ms
+  timing_single_click_2: OFF for at least 250ms
   timing_double_click_1: ON for at most 300ms
   timing_double_click_2: OFF for at most 200ms
   timing_double_click_3: ON for at most 300ms
@@ -139,6 +141,12 @@ globals:
     type: int
     restore_value: false
     initial_value: "0"
+
+  # Group quick-tap guard
+  - id: last_group_toggle_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
 
   # Per-channel quick-tap guards
   - id: last_user_toggle_ms_a
@@ -485,7 +493,7 @@ select:
 number: []
 
 binary_sensor:
-  # Physical A — instant single with quick-tap guard
+  # Physical A — single/double/hold handling with quick-tap guard
   - platform: gpio
     id: button_a
     internal: true
@@ -497,29 +505,8 @@ binary_sensor:
     filters:
       - delayed_on: ${filter_delay_on}
       - delayed_off: ${filter_delay_off}
-    on_press:
-      - if:
-          condition:
-            lambda: 'return (millis() - id(last_user_toggle_ms_a)) >= (uint32_t) ${min_toggle_interval_ms};'
-          then:
-            - lambda: 'id(last_user_toggle_ms_a) = millis();'
-            - if:
-                condition:
-                  lambda: 'return id(mode_a).state == std::string("Coupled");'
-                then:
-                  # In Coupled, toggle relay and fire HA action based on resulting state
-                  - if:
-                      condition:
-                        lambda: 'return id(relay_a).state == false;'
-                      then:
-                        - script.execute: a_on_action
-                      else:
-                        - script.execute: a_off_action
-                  - switch.toggle: relay_a
-                else:
-                  # In Decoupled, toggle virtual state (triggers a_*_action)
-                  - switch.toggle: button_a_state
     on_multi_click:
+      # Double click
       - timing:
           - ${timing_double_click_1}
           - ${timing_double_click_2}
@@ -528,6 +515,7 @@ binary_sensor:
         then:
           - button.press: button_a_sim_double
           - script.execute: a_double_press
+      # Hold (repeat)
       - timing:
           - ${timing_hold}
         then:
@@ -540,8 +528,40 @@ binary_sensor:
                 - script.execute: a_hold_press
                 - delay: ${timing_hold_repeat}
           - light.turn_off: led_status
+      # Single click
+      - timing:
+          - ${timing_single_click_1}
+          - ${timing_single_click_2}
+        then:
+          - if:
+              condition:
+                lambda: 'return (millis() - id(last_group_toggle_ms)) >= (uint32_t) ${min_toggle_interval_ms};'
+              then:
+                - if:
+                    condition:
+                      lambda: 'return (millis() - id(last_user_toggle_ms_a)) >= (uint32_t) ${min_toggle_interval_ms};'
+                    then:
+                      - lambda: |-
+                          id(last_user_toggle_ms_a) = millis();
+                          id(last_group_toggle_ms) = id(last_user_toggle_ms_a);
+                      - if:
+                          condition:
+                            lambda: 'return id(mode_a).state == std::string("Coupled");'
+                          then:
+                            # In Coupled, toggle relay and fire HA action based on resulting state
+                            - if:
+                                condition:
+                                  lambda: 'return id(relay_a).state == false;'
+                                then:
+                                  - script.execute: a_on_action
+                                else:
+                                  - script.execute: a_off_action
+                            - switch.toggle: relay_a
+                          else:
+                            # In Decoupled, toggle virtual state (triggers a_*_action)
+                            - switch.toggle: button_a_state
 
-  # Physical B — instant single with quick-tap guard
+  # Physical B — single/double/hold handling with quick-tap guard
   - platform: gpio
     id: button_b
     internal: true
@@ -553,29 +573,8 @@ binary_sensor:
     filters:
       - delayed_on: ${filter_delay_on}
       - delayed_off: ${filter_delay_off}
-    on_press:
-      - if:
-          condition:
-            lambda: 'return (millis() - id(last_user_toggle_ms_b)) >= (uint32_t) ${min_toggle_interval_ms};'
-          then:
-            - lambda: 'id(last_user_toggle_ms_b) = millis();'
-            - if:
-                condition:
-                  lambda: 'return id(mode_b).state == std::string("Coupled");'
-                then:
-                  # In Coupled, toggle relay and fire HA action based on resulting state
-                  - if:
-                      condition:
-                        lambda: 'return id(relay_b).state == false;'
-                      then:
-                        - script.execute: b_on_action
-                      else:
-                        - script.execute: b_off_action
-                  - switch.toggle: relay_b
-                else:
-                  # In Decoupled, toggle virtual state (triggers b_*_action)
-                  - switch.toggle: button_b_state
     on_multi_click:
+      # Double click
       - timing:
           - ${timing_double_click_1}
           - ${timing_double_click_2}
@@ -584,6 +583,7 @@ binary_sensor:
         then:
           - button.press: button_b_sim_double
           - script.execute: b_double_press
+      # Hold (repeat)
       - timing:
           - ${timing_hold}
         then:
@@ -596,6 +596,38 @@ binary_sensor:
                 - script.execute: b_hold_press
                 - delay: ${timing_hold_repeat}
           - light.turn_off: led_status
+      # Single click
+      - timing:
+          - ${timing_single_click_1}
+          - ${timing_single_click_2}
+        then:
+          - if:
+              condition:
+                lambda: 'return (millis() - id(last_group_toggle_ms)) >= (uint32_t) ${min_toggle_interval_ms};'
+              then:
+                - if:
+                    condition:
+                      lambda: 'return (millis() - id(last_user_toggle_ms_b)) >= (uint32_t) ${min_toggle_interval_ms};'
+                    then:
+                      - lambda: |-
+                          id(last_user_toggle_ms_b) = millis();
+                          id(last_group_toggle_ms) = id(last_user_toggle_ms_b);
+                      - if:
+                          condition:
+                            lambda: 'return id(mode_b).state == std::string("Coupled");'
+                          then:
+                            # In Coupled, toggle relay and fire HA action based on resulting state
+                            - if:
+                                condition:
+                                  lambda: 'return id(relay_b).state == false;'
+                                then:
+                                  - script.execute: b_on_action
+                                else:
+                                  - script.execute: b_off_action
+                            - switch.toggle: relay_b
+                          else:
+                            # In Decoupled, toggle virtual state (triggers b_*_action)
+                            - switch.toggle: button_b_state
 
 script:
   # A actions


### PR DESCRIPTION
## Summary
- Route physical buttons through `on_multi_click` with an explicit single-click pattern
- Share single, double, and hold logic for both gangs using a common quick-tap guard

## Testing
- `yamllint -c .yamllint switchman_m5_1_gang.yaml switchman_m5_2_gang.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68ac9eb98bc483248de69aec9d975d30