### PR TITLE
Align virtual and physical button presses, bump version to 5.0.0

### DIFF
--- a/switchman_m5_1_gang.yaml
+++ b/switchman_m5_1_gang.yaml
@@ -4,7 +4,7 @@ substitutions:
   device_ip: ""
   device_make: "Sonoff"
   device_model: "Switchman M5 (1-Gang)"
-  package_version: "4.1.1"
+  package_version: "5.0.0"
 
   api_key: !secret api_key
   wifi_ssid: !secret wifi_ssid
@@ -253,7 +253,9 @@ switch:
           condition:
             lambda: 'return id(mode_a).state == std::string("Coupled") && id(button_a_state).state == false;'
           then:
-            - switch.turn_on: button_a_state
+            - switch.template.publish:
+                id: button_a_state
+                state: ON
     on_turn_off:
       - switch.turn_off: led_indicator
       # Do NOT trigger HA services here to avoid feedback loops
@@ -261,13 +263,19 @@ switch:
           condition:
             lambda: 'return id(mode_a).state == std::string("Coupled") && id(button_a_state).state == true;'
           then:
-            - switch.turn_off: button_a_state
+            - switch.template.publish:
+                id: button_a_state
+                state: OFF
 
   - platform: template
     name: "Button A state"
     id: button_a_state
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
+    turn_on_action:
+      - script.execute: a_single_press
+    turn_off_action:
+      - script.execute: a_single_press
     on_turn_on:
       - switch.turn_on: led_indicator
       - if:
@@ -363,27 +371,7 @@ binary_sensor:
       - delayed_on: ${filter_delay_on}
       - delayed_off: ${filter_delay_off}
     on_press:
-      - if:
-          condition:
-            lambda: 'return (millis() - id(last_user_toggle_ms)) >= (uint32_t) ${min_toggle_interval_ms};'
-          then:
-            - lambda: 'id(last_user_toggle_ms) = millis();'
-            - if:
-                condition:
-                  lambda: 'return id(mode_a).state == std::string("Coupled");'
-                then:
-                  # In Coupled, toggle relay and fire on/off action based on resulting state
-                  - if:
-                      condition:
-                        lambda: 'return id(relay_a).state == false;'
-                      then:
-                        - script.execute: a_on_action
-                      else:
-                        - script.execute: a_off_action
-                  - switch.toggle: relay_a
-                else:
-                  # In Decoupled, toggle button state (triggers a_*_action)
-                  - switch.toggle: button_a_state
+      - script.execute: a_single_press
     on_multi_click:
       # Double click
       - timing:
@@ -409,6 +397,30 @@ binary_sensor:
           - light.turn_off: led_status
 
 script:
+  - id: a_single_press
+    then:
+      - if:
+          condition:
+            lambda: 'return (millis() - id(last_user_toggle_ms)) >= (uint32_t) ${min_toggle_interval_ms};'
+          then:
+            - lambda: 'id(last_user_toggle_ms) = millis();'
+            - if:
+                condition:
+                  lambda: 'return id(mode_a).state == std::string("Coupled");'
+                then:
+                  - if:
+                      condition:
+                        lambda: 'return id(relay_a).state == false;'
+                      then:
+                        - script.execute: a_on_action
+                      else:
+                        - script.execute: a_off_action
+                  - switch.toggle: relay_a
+                else:
+                  - switch.template.publish:
+                      id: button_a_state
+                      state: !lambda 'return !id(button_a_state).state;'
+
   - id: a_on_action
     then:
       - if:

--- a/switchman_m5_2_gang.yaml
+++ b/switchman_m5_2_gang.yaml
@@ -4,7 +4,7 @@ substitutions:
   device_ip: ""
   device_make: "Sonoff"
   device_model: "Switchman M5 (2-Gang)"
-  package_version: "4.1.1"
+  package_version: "5.0.0"
 
   api_key: !secret api_key
   wifi_ssid: !secret wifi_ssid
@@ -301,14 +301,18 @@ switch:
           condition:
             lambda: 'return id(mode_a).state == std::string("Coupled") && id(button_a_state).state == false;'
           then:
-            - switch.turn_on: button_a_state
+            - switch.template.publish:
+                id: button_a_state
+                state: ON
     on_turn_off:
       - light.turn_off: led_status
       - if:
           condition:
             lambda: 'return id(mode_a).state == std::string("Coupled") && id(button_a_state).state == true;'
           then:
-            - switch.turn_off: button_a_state
+            - switch.template.publish:
+                id: button_a_state
+                state: OFF
 
   # Relay B — keep quiet (no HA calls here)
   - platform: gpio
@@ -322,14 +326,18 @@ switch:
           condition:
             lambda: 'return id(mode_b).state == std::string("Coupled") && id(button_b_state).state == false;'
           then:
-            - switch.turn_on: button_b_state
+            - switch.template.publish:
+                id: button_b_state
+                state: ON
     on_turn_off:
       - switch.turn_off: led_indicator
       - if:
           condition:
             lambda: 'return id(mode_b).state == std::string("Coupled") && id(button_b_state).state == true;'
           then:
-            - switch.turn_off: button_b_state
+            - switch.template.publish:
+                id: button_b_state
+                state: OFF
 
   # Button A state (virtual)
   - platform: template
@@ -337,6 +345,10 @@ switch:
     id: button_a_state
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
+    turn_on_action:
+      - script.execute: a_single_press
+    turn_off_action:
+      - script.execute: a_single_press
     on_turn_on:
       - light.turn_on: led_status
       # Only call HA action when DECOUPLED
@@ -372,6 +384,10 @@ switch:
     id: button_b_state
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
+    turn_on_action:
+      - script.execute: b_single_press
+    turn_off_action:
+      - script.execute: b_single_press
     on_turn_on:
       - switch.turn_on: led_indicator
       - if:
@@ -498,27 +514,7 @@ binary_sensor:
       - delayed_on: ${filter_delay_on}
       - delayed_off: ${filter_delay_off}
     on_press:
-      - if:
-          condition:
-            lambda: 'return (millis() - id(last_user_toggle_ms_a)) >= (uint32_t) ${min_toggle_interval_ms};'
-          then:
-            - lambda: 'id(last_user_toggle_ms_a) = millis();'
-            - if:
-                condition:
-                  lambda: 'return id(mode_a).state == std::string("Coupled");'
-                then:
-                  # In Coupled, toggle relay and fire HA action based on resulting state
-                  - if:
-                      condition:
-                        lambda: 'return id(relay_a).state == false;'
-                      then:
-                        - script.execute: a_on_action
-                      else:
-                        - script.execute: a_off_action
-                  - switch.toggle: relay_a
-                else:
-                  # In Decoupled, toggle virtual state (triggers a_*_action)
-                  - switch.toggle: button_a_state
+      - script.execute: a_single_press
     on_multi_click:
       - timing:
           - ${timing_double_click_1}
@@ -554,27 +550,7 @@ binary_sensor:
       - delayed_on: ${filter_delay_on}
       - delayed_off: ${filter_delay_off}
     on_press:
-      - if:
-          condition:
-            lambda: 'return (millis() - id(last_user_toggle_ms_b)) >= (uint32_t) ${min_toggle_interval_ms};'
-          then:
-            - lambda: 'id(last_user_toggle_ms_b) = millis();'
-            - if:
-                condition:
-                  lambda: 'return id(mode_b).state == std::string("Coupled");'
-                then:
-                  # In Coupled, toggle relay and fire HA action based on resulting state
-                  - if:
-                      condition:
-                        lambda: 'return id(relay_b).state == false;'
-                      then:
-                        - script.execute: b_on_action
-                      else:
-                        - script.execute: b_off_action
-                  - switch.toggle: relay_b
-                else:
-                  # In Decoupled, toggle virtual state (triggers b_*_action)
-                  - switch.toggle: button_b_state
+      - script.execute: b_single_press
     on_multi_click:
       - timing:
           - ${timing_double_click_1}
@@ -598,6 +574,54 @@ binary_sensor:
           - light.turn_off: led_status
 
 script:
+  - id: a_single_press
+    then:
+      - if:
+          condition:
+            lambda: 'return (millis() - id(last_user_toggle_ms_a)) >= (uint32_t) ${min_toggle_interval_ms};'
+          then:
+            - lambda: 'id(last_user_toggle_ms_a) = millis();'
+            - if:
+                condition:
+                  lambda: 'return id(mode_a).state == std::string("Coupled");'
+                then:
+                  - if:
+                      condition:
+                        lambda: 'return id(relay_a).state == false;'
+                      then:
+                        - script.execute: a_on_action
+                      else:
+                        - script.execute: a_off_action
+                  - switch.toggle: relay_a
+                else:
+                  - switch.template.publish:
+                      id: button_a_state
+                      state: !lambda 'return !id(button_a_state).state;'
+
+  - id: b_single_press
+    then:
+      - if:
+          condition:
+            lambda: 'return (millis() - id(last_user_toggle_ms_b)) >= (uint32_t) ${min_toggle_interval_ms};'
+          then:
+            - lambda: 'id(last_user_toggle_ms_b) = millis();'
+            - if:
+                condition:
+                  lambda: 'return id(mode_b).state == std::string("Coupled");'
+                then:
+                  - if:
+                      condition:
+                        lambda: 'return id(relay_b).state == false;'
+                      then:
+                        - script.execute: b_on_action
+                      else:
+                        - script.execute: b_off_action
+                  - switch.toggle: relay_b
+                else:
+                  - switch.template.publish:
+                      id: button_b_state
+                      state: !lambda 'return !id(button_b_state).state;'
+
   # A actions
   - id: a_on_action
     then:


### PR DESCRIPTION
## Summary
- Centralize button handling so Home Assistant template switches mimic physical presses
- Publish template switch state directly to avoid recursion
- Bump package_version substitution to 5.0.0 for both configurations

## Testing
- `esphome compile switchman_m5_1_gang.yaml`
- `esphome compile switchman_m5_2_gang.yaml`
- `yamllint switchman_m5_1_gang.yaml switchman_m5_2_gang.yaml` *(truthy value warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68acb8a423a88324bc239612ca3589c3