### PR TITLE
Prevent strobing on rapid toggles

### DIFF
--- a/switchman_m5_1_gang.yaml
+++ b/switchman_m5_1_gang.yaml
@@ -403,7 +403,6 @@ script:
           condition:
             lambda: 'return (millis() - id(last_user_toggle_ms)) >= (uint32_t) ${min_toggle_interval_ms};'
           then:
-            - lambda: 'id(last_user_toggle_ms) = millis();'
             - if:
                 condition:
                   lambda: 'return id(mode_a).state == std::string("Coupled");'
@@ -420,6 +419,19 @@ script:
                   - switch.template.publish:
                       id: button_a_state
                       state: !lambda 'return !id(button_a_state).state;'
+          else:
+            - if:
+                condition:
+                  lambda: 'return id(mode_a).state == std::string("Coupled");'
+                then:
+                  - switch.template.publish:
+                      id: button_a_state
+                      state: !lambda 'return id(relay_a).state;'
+                else:
+                  - switch.template.publish:
+                      id: button_a_state
+                      state: !lambda 'return !id(button_a_state).state;'
+      - lambda: 'id(last_user_toggle_ms) = millis();'
 
   - id: a_on_action
     then:

--- a/switchman_m5_2_gang.yaml
+++ b/switchman_m5_2_gang.yaml
@@ -580,7 +580,6 @@ script:
           condition:
             lambda: 'return (millis() - id(last_user_toggle_ms_a)) >= (uint32_t) ${min_toggle_interval_ms};'
           then:
-            - lambda: 'id(last_user_toggle_ms_a) = millis();'
             - if:
                 condition:
                   lambda: 'return id(mode_a).state == std::string("Coupled");'
@@ -597,6 +596,19 @@ script:
                   - switch.template.publish:
                       id: button_a_state
                       state: !lambda 'return !id(button_a_state).state;'
+          else:
+            - if:
+                condition:
+                  lambda: 'return id(mode_a).state == std::string("Coupled");'
+                then:
+                  - switch.template.publish:
+                      id: button_a_state
+                      state: !lambda 'return id(relay_a).state;'
+                else:
+                  - switch.template.publish:
+                      id: button_a_state
+                      state: !lambda 'return !id(button_a_state).state;'
+      - lambda: 'id(last_user_toggle_ms_a) = millis();'
 
   - id: b_single_press
     then:
@@ -604,7 +616,6 @@ script:
           condition:
             lambda: 'return (millis() - id(last_user_toggle_ms_b)) >= (uint32_t) ${min_toggle_interval_ms};'
           then:
-            - lambda: 'id(last_user_toggle_ms_b) = millis();'
             - if:
                 condition:
                   lambda: 'return id(mode_b).state == std::string("Coupled");'
@@ -621,6 +632,19 @@ script:
                   - switch.template.publish:
                       id: button_b_state
                       state: !lambda 'return !id(button_b_state).state;'
+          else:
+            - if:
+                condition:
+                  lambda: 'return id(mode_b).state == std::string("Coupled");'
+                then:
+                  - switch.template.publish:
+                      id: button_b_state
+                      state: !lambda 'return id(relay_b).state;'
+                else:
+                  - switch.template.publish:
+                      id: button_b_state
+                      state: !lambda 'return !id(button_b_state).state;'
+      - lambda: 'id(last_user_toggle_ms_b) = millis();'
 
   # A actions
   - id: a_on_action


### PR DESCRIPTION
## Summary
- debounce button presses so rapid on/off sequences don't strobe relays
- keep button state in sync when rapid toggles are ignored

## Testing
- `yamllint switchman_m5_1_gang.yaml switchman_m5_2_gang.yaml`
- `esphome config switchman_m5_1_gang.yaml`
- `esphome config switchman_m5_2_gang.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68addb5d99fc832484825ef5072a3087